### PR TITLE
✨ More strategy errors

### DIFF
--- a/apps/contracts/strategies/blend/src/blend_pool.rs
+++ b/apps/contracts/strategies/blend/src/blend_pool.rs
@@ -161,7 +161,7 @@ pub fn perform_reinvest(e: &Env, config: &Config) -> Result<bool, StrategyError>
     )?;
     let amount_out: i128 = swapped_amounts
         .get(1)
-        .ok_or(StrategyError::InvalidArgument)?
+        .ok_or(StrategyError::InternalSwapError)?
         .into_val(e);
 
     // Supplying underlying asset into blend pool

--- a/apps/contracts/strategies/blend/src/lib.rs
+++ b/apps/contracts/strategies/blend/src/lib.rs
@@ -88,7 +88,7 @@ impl DeFindexStrategyTrait for BlendStrategy {
         // protect against rouding of reserve_vault::update_rate, as small amounts
         // can cause incorrect b_rate calculations due to the pool rounding
         if amount < MIN_DUST {
-            return Err(StrategyError::InvalidArgument); //TODO: create a new error type for this
+            return Err(StrategyError::AmountBelowMinDust);
         }
 
         let config = storage::get_config(&e);

--- a/apps/contracts/strategies/blend/src/reserves.rs
+++ b/apps/contracts/strategies/blend/src/reserves.rs
@@ -62,11 +62,11 @@ pub fn deposit(
     b_tokens_amount: i128,
 ) -> i128 {
     if underlying_amount <= 0 {
-        panic_with_error!(e, StrategyError::InvalidArgument); //TODO: create a new error type for this
+        panic_with_error!(e, StrategyError::UnderlyingAmountBelowMin); 
     }
 
     if b_tokens_amount <= 0 {
-        panic_with_error!(e, StrategyError::InvalidArgument); //TODO: create a new error type for this
+        panic_with_error!(e, StrategyError::BTokensAmountBelowMin); 
     }
 
     reserves.update_rate(underlying_amount, b_tokens_amount);

--- a/apps/contracts/strategies/blend/src/test/blend/error.rs
+++ b/apps/contracts/strategies/blend/src/test/blend/error.rs
@@ -1,0 +1,68 @@
+#![cfg(test)]
+use crate::test::blend::soroswap_setup::create_soroswap_pool;
+use crate::test::{create_blend_pool, create_blend_strategy, BlendFixture, EnvTestUtils};
+use crate::BlendStrategyClient;
+use defindex_strategy_core::StrategyError;
+use sep_41_token::testutils::MockTokenClient;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+#[test]
+fn amount_below_min_dust() {
+    // Setting up the environment
+    let e = Env::default();
+    e.budget().reset_unlimited();
+    e.mock_all_auths();
+    e.set_default_info();
+
+    // Setting up the users
+    let admin = Address::generate(&e);
+    let user_2 = Address::generate(&e);
+
+    // Setting up the assets
+    let blnd = e.register_stellar_asset_contract_v2(admin.clone());
+    let usdc = e.register_stellar_asset_contract_v2(admin.clone());
+    let xlm = e.register_stellar_asset_contract_v2(admin.clone());
+
+    // Setting up the token clients
+    let blnd_client = MockTokenClient::new(&e, &blnd.address());
+    let usdc_client = MockTokenClient::new(&e, &usdc.address());
+    let xlm_client = MockTokenClient::new(&e, &xlm.address());
+
+    // Setting up soroswap pool
+    let pool_admin = Address::generate(&e);
+    let amount_a = 100000000_0_000_000;
+    let amount_b = 50000000_0_000_000;
+    blnd_client.mint(&pool_admin, &amount_a);
+    usdc_client.mint(&pool_admin, &amount_b);
+    let soroswap_router = create_soroswap_pool(
+        &e,
+        &pool_admin,
+        &blnd.address(),
+        &usdc.address(),
+        &amount_a,
+        &amount_b,
+    );
+    // End of setting up soroswap pool
+
+    let blend_fixture = BlendFixture::deploy(&e, &admin, &blnd.address(), &usdc.address());
+
+    let pool = create_blend_pool(&e, &blend_fixture, &admin, &usdc_client, &xlm_client);
+    let strategy = create_blend_strategy(
+        &e,
+        &usdc.address(),
+        &pool,
+        &0u32,
+        &blnd.address(),
+        &soroswap_router.address,
+    );
+    let strategy_client = BlendStrategyClient::new(&e, &strategy);
+
+    let starting_balance = 100_0000000;
+    usdc_client.mint(&user_2, &starting_balance);
+
+    //Trying to deposit below the min dust
+    let deposit_below_min_dust = strategy_client.try_deposit(&9999i128, &user_2);
+    
+    assert_eq!(deposit_below_min_dust, Err(Ok(StrategyError::AmountBelowMinDust)));
+}

--- a/apps/contracts/strategies/blend/src/test/blend/mod.rs
+++ b/apps/contracts/strategies/blend/src/test/blend/mod.rs
@@ -1,2 +1,3 @@
 mod soroswap_setup;
 mod success;
+mod error;

--- a/apps/contracts/strategies/core/src/error.rs
+++ b/apps/contracts/strategies/core/src/error.rs
@@ -16,4 +16,11 @@ pub enum StrategyError {
     ProtocolAddressNotFound = 420,
     DeadlineExpired = 421,
     ExternalError = 422,
+
+    //Blend Errors
+    AmountBelowMinDust = 451,
+    UnderlyingAmountBelowMin = 452,
+    BTokensAmountBelowMin = 453,
+    InternalSwapError = 454,
+
 }


### PR DESCRIPTION
Add new errors related to blend strategy to the strategies core:

```
    //Blend Errors
    AmountBelowMinDust = 451,
    UnderlyingAmountBelowMin = 452,
    BTokensAmountBelowMin = 453,
    InternalSwapError = 454,
```
