### PR TITLE
Rename emergency_withdraw & ActionType::Withdraw

### DIFF
--- a/apps/contracts/src/tests/mainTest.ts
+++ b/apps/contracts/src/tests/mainTest.ts
@@ -213,7 +213,7 @@ async function testVaultOneStrategy() {
       amount: BigInt(7_0_000),
     },
     {
-      type: "Withdraw",
+      type: "Unwind",
       strategy: addressBook.getContractId("hodl_strategy"),
       amount: BigInt(6_0_00),
     },
@@ -427,7 +427,7 @@ async function testVaultTwoStrategies() {
           amount: BigInt(7_000_000),
       },
       {
-          type: "Withdraw",
+          type: "Unwind",
           strategy: addressBook.getContractId("hodl_strategy"),
           amount: BigInt(6_000_00),
       },
@@ -437,7 +437,7 @@ async function testVaultTwoStrategies() {
           amount: BigInt(8_000_000),
       },
       {
-          type: "Withdraw",
+          type: "Unwind",
           strategy: addressBook.getContractId("fixed_apr_strategy"),
           amount: BigInt(3_000_00),
       },

--- a/apps/contracts/src/tests/vault.ts
+++ b/apps/contracts/src/tests/vault.ts
@@ -529,7 +529,7 @@ export type Option<T> = T | undefined;
 // export type u64 = number; // Simplified as a number for UNIX timestamps
 
 export type Instruction =
-  | { type: "Withdraw"; strategy: string; amount: i128 }
+  | { type: "Unwind"; strategy: string; amount: i128 }
   | { type: "Invest"; strategy: string; amount: i128 }
   | {
       type: "SwapExactIn";
@@ -555,7 +555,7 @@ export function mapInstructionsToParams(
     instructions.map((instruction) => {
       switch (instruction.type) {
         case "Invest":
-        case "Withdraw":
+        case "Unwind":
           // Handle Invest and Withdraw actions
           return xdr.ScVal.scvVec([
             xdr.ScVal.scvSymbol(instruction.type), // "Invest" or "Withdraw"

--- a/apps/contracts/vault/src/events.rs
+++ b/apps/contracts/vault/src/events.rs
@@ -66,7 +66,7 @@ pub struct EmergencyWithdrawEvent {
 }
 
 /// Publishes an `EmergencyWithdrawEvent` to the event stream.
-pub(crate) fn emit_emergency_withdraw_event(
+pub(crate) fn emit_rescue_event(
     e: &Env,
     caller: Address,
     strategy_address: Address,
@@ -79,7 +79,7 @@ pub(crate) fn emit_emergency_withdraw_event(
     };
 
     e.events()
-        .publish(("DeFindexVault", symbol_short!("ewithdraw")), event);
+        .publish(("DeFindexVault", symbol_short!("rescue")), event);
 }
 
 // STRATEGY PAUSED EVENT

--- a/apps/contracts/vault/src/interface.rs
+++ b/apps/contracts/vault/src/interface.rs
@@ -110,7 +110,7 @@ pub trait VaultTrait {
     ///
     /// # Returns:
     /// * `Result<(), ContractError>` - Ok if successful, otherwise returns a ContractError.
-    fn emergency_withdraw(
+    fn rescue(
         e: Env,
         strategy_address: Address,
         caller: Address,

--- a/apps/contracts/vault/src/lib.rs
+++ b/apps/contracts/vault/src/lib.rs
@@ -357,7 +357,7 @@ impl VaultTrait for DeFindexVault {
     ///
     /// # Returns:
     /// * `Result<(), ContractError>` - Ok if successful, otherwise returns a ContractError.
-    fn emergency_withdraw(
+    fn rescue(
         e: Env,
         strategy_address: Address,
         caller: Address,
@@ -396,7 +396,7 @@ impl VaultTrait for DeFindexVault {
         // Pause the strategy
         pause_strategy(&e, strategy_address.clone())?;
 
-        events::emit_emergency_withdraw_event(&e, caller, strategy_address, strategy_balance);
+        events::emit_rescue_event(&e, caller, strategy_address, strategy_balance);
         Ok(())
     }
 
@@ -786,7 +786,7 @@ impl VaultManagementTrait for DeFindexVault {
 
         for instruction in instructions.iter() {
             match instruction {
-                Instruction::Withdraw(strategy_address, amount) => {
+                Instruction::Unwind(strategy_address, amount) => {
                     unwind_from_strategy(
                         &e,
                         &strategy_address,

--- a/apps/contracts/vault/src/models.rs
+++ b/apps/contracts/vault/src/models.rs
@@ -30,7 +30,7 @@ pub struct AssetInvestmentAllocation {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Instruction {
     /// Withdraw funds from a strategy.
-    Withdraw(Address, i128), // (strategy, amount)
+    Unwind(Address, i128), // (strategy, amount)
 
     /// Invest funds into a strategy.
     Invest(Address, i128), // (strategy, amount)

--- a/apps/contracts/vault/src/test/vault/budget.rs
+++ b/apps/contracts/vault/src/test/vault/budget.rs
@@ -161,7 +161,7 @@ fn budget() {
     // rebalance withdraw
     let withdraw_instructions = sorobanvec![
         &test.env,
-        Instruction::Withdraw(test.strategy_client_token_0.address.clone(), 100),
+        Instruction::Unwind(test.strategy_client_token_0.address.clone(), 100),
     ];
     let _ = defindex_contract.rebalance(&test.rebalance_manager, &withdraw_instructions);
     let mem = test.env.budget().memory_bytes_cost();

--- a/apps/contracts/vault/src/test/vault/events.rs
+++ b/apps/contracts/vault/src/test/vault/events.rs
@@ -157,7 +157,7 @@ fn check_rebalance_events(){
   let instruction_amount_0 = 2_000i128;
   let instructions = sorobanvec![
         &test.env,
-        Instruction::Withdraw(
+        Instruction::Unwind(
             test.strategy_client_token_0.address.clone(),
             instruction_amount_0
         ),

--- a/apps/contracts/vault/src/test/vault/mod.rs
+++ b/apps/contracts/vault/src/test/vault/mod.rs
@@ -2,7 +2,7 @@ mod admin;
 mod budget;
 mod deposit;
 mod deposit_and_invest;
-mod emergency_withdraw;
+mod rescue;
 mod events;
 mod fees;
 mod get_asset_amounts_per_shares;

--- a/apps/contracts/vault/src/test/vault/rebalance.rs
+++ b/apps/contracts/vault/src/test/vault/rebalance.rs
@@ -92,7 +92,7 @@ fn multi_instructions() {
 
     let instructions = sorobanvec![
         &test.env,
-        Instruction::Withdraw(
+        Instruction::Unwind(
             test.strategy_client_token_0.address.clone(),
             instruction_amount_0
         ),
@@ -189,7 +189,7 @@ fn one_instruction() {
 
     let instructions = sorobanvec![
         &test.env,
-        Instruction::Withdraw(
+        Instruction::Unwind(
             test.strategy_client_token_0.address.clone(),
             instruction_amount_0
         ),
@@ -352,7 +352,7 @@ fn insufficient_balance() {
     //Withdraw with no funds
     let withdraw_no_funds_instructions = sorobanvec![
         &test.env,
-        Instruction::Withdraw(test.strategy_client_token_0.address.clone(), amount + 1),
+        Instruction::Unwind(test.strategy_client_token_0.address.clone(), amount + 1),
     ];
 
     let withdraw_no_funds = defindex_contract.try_rebalance(&test.rebalance_manager, &withdraw_no_funds_instructions);
@@ -386,7 +386,7 @@ fn insufficient_balance() {
     //Withdraw more than available
     let withdraw_instructions = sorobanvec![
         &test.env,
-        Instruction::Withdraw(test.strategy_client_token_0.address.clone(), amount + 1),
+        Instruction::Unwind(test.strategy_client_token_0.address.clone(), amount + 1),
     ];
 
     let rebalance = defindex_contract.try_rebalance(&test.rebalance_manager, &withdraw_instructions);

--- a/apps/contracts/vault/src/test/vault/rescue.rs
+++ b/apps/contracts/vault/src/test/vault/rescue.rs
@@ -7,7 +7,7 @@ use crate::test::{
 };
 
 #[test]
-fn withdraw_success() {
+fn rescue_success() {
     let test = DeFindexVaultTest::setup();
     test.env.mock_all_auths();
     let strategy_params_token_0 = create_strategy_params_token_0(&test);
@@ -93,7 +93,7 @@ fn withdraw_success() {
         .balance(&defindex_contract.address);
     assert_eq!(strategy_balance, amount);
 
-    defindex_contract.emergency_withdraw(
+    defindex_contract.rescue(
         &strategy_params_token_0.first().unwrap().address,
         &test.emergency_manager,
     );

--- a/apps/docs/10-whitepaper/03-the-defindex-approach/01-design-decisions.md
+++ b/apps/docs/10-whitepaper/03-the-defindex-approach/01-design-decisions.md
@@ -14,11 +14,11 @@ To understand better why we decide this please check the [Why we can`t swap on d
 
 ## IDLE funds.
 IDLE funds are funds that are not being used for any strategy. But they are protected by being held inside the DeFindex Smart Contracts.
-- Security: Enables emergency withdrawal. This means that if a DeFi protocol gets too risky, the users won't lose their funds because they can be withdrawn from the DeFi protocol to the DeFindex Smart Contracts.
+- Security: Enables `rescue`. This means that if a DeFi protocol gets too risky, the users won't lose their funds because they can be withdrawn from the DeFi protocol to the DeFindex Smart Contracts.
 - Performance: Enable multi transaction movements.
 - Transaction Cost: Enable small transactions that wont be affected by costly txs.
 
-## Emergency Withdrawal
+## Rescue
 - It allows the Emergency Manager to rescue funds in case of an emergency. These are held in the DeFindex Smart Contracts. Thus, the users won't lose their funds and they will be able to withdraw them anytime.
 
 ## Roles

--- a/apps/docs/10-whitepaper/03-the-defindex-approach/02-contracts/01-vault-contract.md
+++ b/apps/docs/10-whitepaper/03-the-defindex-approach/02-contracts/01-vault-contract.md
@@ -2,7 +2,7 @@
 # DeFindex Vault Contract
 This contract serves as the core of the DeFindex platform, responsible for managing assets, executing strategies, and ensuring proper asset rebalancing. It operates with four primary roles: **Deployer**, **Fee Receiver**, **Manager**, **rebalancer** and **Emergency Manager**. Additionally, the contract functions as a token referred to as the *dfToken* that represents the shares of the vault.
 
-While anyone can invest in a DeFindex, only the Manager and Emergency Manager have the authority to move funds between strategies or even outside strategies and into the Vault itself (see idle assets and emergency withdrawal).
+While anyone can invest in a DeFindex, only the Manager and Emergency Manager have the authority to move funds between strategies or even outside strategies and into the Vault itself (see idle assets and rescue).
 
 The contract also holds funds not currently invested in any strategy, known as **IDLE funds**. These funds act as a safety buffer, allowing the Emergency Manager to withdraw assets from underperforming or unhealthy strategies and store them as IDLE funds. (also to enable fast small withdrawals)
 
@@ -129,7 +129,7 @@ When dealing with multi-asset vaults, the rebalancing process may require tradin
 - `rebalance`: Allows the Manager to rebalance the DeFindex. It executes `withdraw_from_strategies`, `internal_swap`, and `invest_in_strategies` functions.
 
 Then, a rebalance execution will withdraw assets from the strategies, swap them, and invest them back in the strategies.
-- `emergency_withdraw`: Allows the Emergency Manager to withdraw all assets from a specific Strategy. As arguments, it receives the the address of a Strategy. It also turns off the strategy.
+- `rescue`: Allows the Emergency Manager to withdraw all assets from a specific Strategy. As arguments, it receives the the address of a Strategy. It also turns off the strategy.
 
 ## Emergency Management
 The Emergency Manager has the authority to withdraw assets from the DeFindex in case of an emergency. This role is designed to protect users' assets in the event of a critical situation, such as a hack of a underlying protocol or a if a strategy gets unhealthy. The Emergency Manager can withdraw assets from the Strategy and store them as IDLE funds inside the Vault until the situation is resolved. 

--- a/apps/docs/10-whitepaper/README.md
+++ b/apps/docs/10-whitepaper/README.md
@@ -41,7 +41,7 @@ The protocol comprises three main components:
 To ensure robust functionality and security, DeFindex implements a role-based management system:  
 
 - **Manager:** Oversees strategies and the assets within Vaults.  
-- **Emergency Manager:** Handles emergency withdrawals.  
+- **Emergency Manager:** Handles rescues.  
 - **Fee Receiver:** Collects and manages strategy-related fees.  
 
 By combining simplicity for newcomers with advanced features for seasoned users, DeFindex aims to make DeFi more accessible and efficient on the Stellar Blockchain.

--- a/apps/docs/12-tutorials/01-test-defindex-testnet.md
+++ b/apps/docs/12-tutorials/01-test-defindex-testnet.md
@@ -22,6 +22,6 @@
 1.    Access the Vault: Click on the desired vault to view interaction options.
 2.    Select an Action:
     - Deposit: Add funds to the vault, which will automatically be invested according to the vault’s strategy.
-    - Emergency Withdraw: Withdraw investments from strategies and keep them as idle funds in the vault. (Only accessible to the Manager or Emergency Manager.)
+    - Rescue: Withdraw investments from strategies and keep them as idle funds in the vault. (Only accessible to the Manager or Emergency Manager.)
     - Withdraw: Withdraw your position (dfTokens) from the vault.
 3.    Follow On-Screen Instructions: Each action will guide you through the necessary steps to complete the process.


### PR DESCRIPTION
⚠️WARNING: This pull request includes changes made in #352, please review and megre before this pull request
Changes:
  - [x] Emergency Withdraw for rescue
  - [x] ActionType::Withdraw for ActionType::Unwind
  - [x] On docs, whitepaper should say rescue instead of emergency withdraw

Acceptance criteria:

  - [x] Rust test pass
  - [x] Typescript pass