### PR TITLE
🩹[AUDIT] Refactor factory storage

### DIFF
--- a/apps/contracts/factory/src/storage.rs
+++ b/apps/contracts/factory/src/storage.rs
@@ -45,15 +45,15 @@ fn get_persistent_extend_or_error<V: TryFromVal<Env, Val>>(
 
 pub fn get_vault_wasm_hash(e: &Env) -> Result<BytesN<32>, FactoryError> {
     let key = DataKey::DeFindexWasmHash;
-    get_persistent_extend_or_error(&e, &key, FactoryError::NotInitialized)
+    e.storage().instance().get(&key).ok_or(FactoryError::NotInitialized)
 }
 
 pub fn put_vault_wasm_hash(e: &Env, vault_wasm_hash: BytesN<32>) {
     let key = DataKey::DeFindexWasmHash;
-    e.storage().persistent().set(&key, &vault_wasm_hash);
+    e.storage().instance().set(&key, &vault_wasm_hash);
     e.storage()
-        .persistent()
-        .extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT)
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 }
 
 // Storing deployed vaults

--- a/apps/contracts/factory/src/test/factory/initialize.rs
+++ b/apps/contracts/factory/src/test/factory/initialize.rs
@@ -1,15 +1,12 @@
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Env, BytesN};
 use crate::error::FactoryError;
+use crate::storage::DataKey;
 use crate::test::{create_defindex_factory, defindex_vault_contract, DeFindexFactoryTest, DeFindexFactoryClient};
 use crate::constants::MAX_DEFINDEX_FEE;
-extern crate std;
 
-impl std::fmt::Debug for DeFindexFactoryClient<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DeFindexFactoryClient {{ ... }}")
-    }
+fn retrieve_value(env: &Env, key: DataKey) -> Result<BytesN<32>, FactoryError> {
+    env.storage().instance().get(&key).ok_or(FactoryError::NotInitialized)
 }
-
 
 #[test]
 fn get_storage() {
@@ -17,10 +14,14 @@ fn get_storage() {
 
     let factory_admin = test.factory_contract.admin();
     let factory_defindex_receiver = test.factory_contract.defindex_receiver();
+    let key = DataKey::DeFindexWasmHash;
+    let vault_wasm = test.env.as_contract(&test.factory_contract.address,|| retrieve_value(&test.env, key));
 
+    assert_eq!(vault_wasm.unwrap(), test.defindex_wasm_hash);
     assert_eq!(factory_admin, test.admin);
     assert_eq!(factory_defindex_receiver, test.defindex_receiver);
 }
+
 
 #[test]
 #[should_panic(expected = "HostError: Error(Context, InvalidAction)")] //FactoryError::FeeTooHigh (#406)


### PR DESCRIPTION
- [x] Moved vault_wasm_hash from persistent storage to insrance to resolve #467 