### PR TITLE
🔥 [Vault] Remove factory on vault constructor

### DIFF
--- a/apps/contracts/factory/src/lib.rs
+++ b/apps/contracts/factory/src/lib.rs
@@ -203,7 +203,6 @@ fn create_vault_internal(
     name_symbol: Map<String, String>,
     upgradable: bool,
 ) -> Result<Address, FactoryError> {
-    let current_contract = e.current_contract_address();
     let vault_wasm_hash = get_vault_wasm_hash(e)?;
     let defindex_receiver = get_defindex_receiver(e)?;
     let defindex_fee = get_fee_rate(e)?;
@@ -214,7 +213,6 @@ fn create_vault_internal(
     init_args.push_back(vault_fee.into_val(e));
     init_args.push_back(defindex_receiver.to_val());
     init_args.push_back(defindex_fee.into_val(e));
-    init_args.push_back(current_contract.to_val());
     init_args.push_back(soroswap_router.to_val());
     init_args.push_back(name_symbol.to_val());
     init_args.push_back(upgradable.into_val(e));

--- a/apps/contracts/vault/src/interface.rs
+++ b/apps/contracts/vault/src/interface.rs
@@ -19,7 +19,6 @@ pub trait VaultTrait {
     /// * `vault_fee` - Vault-specific fee in basis points (0-2000 for 0-20%)
     /// * `defindex_protocol_receiver` - Address receiving protocol fees
     /// * `defindex_protocol_rate` - Protocol fee rate in basis points (0-9000 for 0-90%)
-    /// * `factory` - Factory contract address
     /// * `soroswap_router` - Soroswap router address
     /// * `name_symbol` - Map containing:
     ///   - "name": Vault token name
@@ -68,7 +67,6 @@ pub trait VaultTrait {
         vault_fee: u32,
         defindex_protocol_receiver: Address,
         defindex_protocol_rate: u32,
-        factory: Address,
         soroswap_router: Address,
         name_symbol: Map<String, String>,
         upgradable: bool,

--- a/apps/contracts/vault/src/lib.rs
+++ b/apps/contracts/vault/src/lib.rs
@@ -32,7 +32,7 @@ use models::{AssetInvestmentAllocation, CurrentAssetInvestmentAllocation, Instru
 use storage::{
     extend_instance_ttl, get_assets, get_defindex_protocol_fee_rate,
     get_report, get_vault_fee, set_asset,
-    set_defindex_protocol_fee_rate, set_defindex_protocol_fee_receiver, set_factory, set_report,
+    set_defindex_protocol_fee_rate, set_defindex_protocol_fee_receiver, set_report,
     set_soroswap_router, set_total_assets, set_vault_fee, set_is_upgradable
 };
 use strategies::{
@@ -70,7 +70,6 @@ impl VaultTrait for DeFindexVault {
     /// * `vault_fee` - Vault-specific fee in basis points (0_2000 for 0.20%)
     /// * `defindex_protocol_receiver` - Address receiving protocol fees
     /// * `defindex_protocol_rate` - Protocol fee rate in basis points (0-9000 for 0-90%)
-    /// * `factory` - Factory contract address
     /// * `soroswap_router` - Soroswap router address
     /// * `name_symbol` - Map containing:
     ///   - "name": Vault token name
@@ -119,7 +118,6 @@ impl VaultTrait for DeFindexVault {
         vault_fee: u32,
         defindex_protocol_receiver: Address,
         defindex_protocol_rate: u32,
-        factory: Address,
         soroswap_router: Address,
         name_symbol: Map<String, String>,
         upgradable: bool,
@@ -145,7 +143,6 @@ impl VaultTrait for DeFindexVault {
         }
         set_defindex_protocol_fee_rate(&e, &defindex_protocol_rate);
 
-        set_factory(&e, &factory);
         set_is_upgradable(&e, &upgradable);
 
         set_soroswap_router(&e, &soroswap_router);

--- a/apps/contracts/vault/src/storage.rs
+++ b/apps/contracts/vault/src/storage.rs
@@ -23,7 +23,6 @@ enum DataKey {
     TotalAssets,           // Total number of tokens
     AssetStrategySet(u32), // AssetStrategySet Addresse by index
     DeFindexProtocolFeeReceiver,
-    DeFindexFactory,
     Upgradable,
     VaultFee,
     SoroswapRouter,
@@ -90,13 +89,6 @@ pub fn get_defindex_protocol_fee_rate(e: &Env) -> u32 {
         .instance()
         .get(&DataKey::DeFindexProtocolFeeRate)
         .unwrap()
-}
-
-// DeFindex Factory
-pub fn set_factory(e: &Env, address: &Address) {
-    e.storage()
-        .instance()
-        .set(&DataKey::DeFindexFactory, address);
 }
 
 // Soroswap Router

--- a/apps/contracts/vault/src/test.rs
+++ b/apps/contracts/vault/src/test.rs
@@ -220,7 +220,6 @@ impl EnvTestUtils for Env {
 
 pub struct DeFindexVaultTest<'a> {
     env: Env,
-    defindex_factory: Address,
     token_0_admin_client: SorobanTokenAdminClient<'a>,
     token_0: SorobanTokenClient<'a>,
     token_1_admin_client: SorobanTokenAdminClient<'a>,
@@ -249,7 +248,6 @@ impl<'a> DeFindexVaultTest<'a> {
         // env.mock_all_auths();
         env.set_default_info();
         // Mockup, should be the factory contract
-        let defindex_factory = Address::generate(&env);
         env.cost_estimate().budget().reset_unlimited();
         let emergency_manager = Address::generate(&env);
         let vault_fee_receiver = Address::generate(&env);
@@ -376,7 +374,6 @@ impl<'a> DeFindexVaultTest<'a> {
 
         DeFindexVaultTest {
             env,
-            defindex_factory,
             token_0_admin_client,
             token_0,
             token_1_admin_client,

--- a/apps/contracts/vault/src/test.rs
+++ b/apps/contracts/vault/src/test.rs
@@ -70,7 +70,6 @@ pub fn create_defindex_vault<'a>(
     vault_fee: u32,
     defindex_protocol_receiver: Address,
     defindex_protocol_rate: u32,
-    factory: Address,
     soroswap_router: Address,
     name_symbol: Map<String, String>,
     upgradable: bool,
@@ -81,7 +80,6 @@ pub fn create_defindex_vault<'a>(
         vault_fee,
         defindex_protocol_receiver,
         defindex_protocol_rate,
-        factory,
         soroswap_router,
         name_symbol,
         upgradable

--- a/apps/contracts/vault/src/test/vault/admin.rs
+++ b/apps/contracts/vault/src/test/vault/admin.rs
@@ -47,7 +47,6 @@ fn set_new_fee_receiver_by_fee_receiver() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -124,7 +123,6 @@ fn set_new_fee_receiver_by_manager() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -199,7 +197,6 @@ fn set_new_fee_receiver_by_emergency_manager() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -248,7 +245,6 @@ fn set_new_fee_receiver_invalid_sender() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -295,7 +291,6 @@ fn set_new_manager_by_manager() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -358,7 +353,6 @@ fn set_new_manager_by_unauthorized_user() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -419,7 +413,6 @@ fn lock_fees_with_new_fee() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true

--- a/apps/contracts/vault/src/test/vault/budget.rs
+++ b/apps/contracts/vault/src/test/vault/budget.rs
@@ -47,7 +47,6 @@ fn budget() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true

--- a/apps/contracts/vault/src/test/vault/deposit.rs
+++ b/apps/contracts/vault/src/test/vault/deposit.rs
@@ -48,7 +48,6 @@ fn amounts_desired_less_length() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -102,7 +101,6 @@ fn amounts_desired_more_length() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -160,7 +158,6 @@ fn amounts_min_less_length() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -218,7 +215,6 @@ fn amounts_min_more_length() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -276,7 +272,6 @@ fn amounts_desired_negative() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -329,7 +324,6 @@ fn one_asset_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -495,7 +489,6 @@ fn one_asset_min_more_than_desired() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -562,7 +555,6 @@ fn several_assets_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -855,7 +847,6 @@ fn several_assets_min_greater_than_optimal() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -959,7 +950,6 @@ fn amounts_min_greater_than_amounts_desired() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1031,7 +1021,6 @@ fn transfers_tokens_from_user_to_vault() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1101,7 +1090,6 @@ fn arithmetic_error() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1175,7 +1163,6 @@ fn amounts_desired_zero() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1249,7 +1236,6 @@ fn insufficient_funds_with_error_message() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1348,7 +1334,6 @@ fn with_zero_amounts() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true,
@@ -1493,7 +1478,6 @@ fn mint_zero_shares(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1561,7 +1545,6 @@ fn mint_negative_shares(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1630,7 +1613,6 @@ fn mint_shares(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true

--- a/apps/contracts/vault/src/test/vault/deposit_and_invest.rs
+++ b/apps/contracts/vault/src/test/vault/deposit_and_invest.rs
@@ -41,7 +41,6 @@ fn one_asset_no_previous_investment() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -204,7 +203,6 @@ fn one_asset_previous_investment_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -405,7 +403,6 @@ fn several_assets_no_previous_investment() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -644,7 +641,6 @@ fn several_assets_wih_previous_investment_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -941,7 +937,6 @@ fn one_asset_several_strategies() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1043,7 +1038,6 @@ fn deposit_simple_then_deposit_and_invest() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1264,7 +1258,6 @@ fn several_assets_several_strategies() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1531,7 +1524,6 @@ fn several_assets_one_strategy_paused() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1726,7 +1718,6 @@ fn several_assets_one_strategy_paused_and_rescue() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true

--- a/apps/contracts/vault/src/test/vault/events.rs
+++ b/apps/contracts/vault/src/test/vault/events.rs
@@ -64,7 +64,6 @@ fn check_rebalance_events(){
       2000u32,
       test.defindex_protocol_receiver.clone(),
       2500u32,
-      test.defindex_factory.clone(),
       test.soroswap_router.address.clone(),
       name_symbol,
       true,
@@ -302,7 +301,6 @@ fn set_new_manager_by_manager() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true

--- a/apps/contracts/vault/src/test/vault/fees.rs
+++ b/apps/contracts/vault/src/test/vault/fees.rs
@@ -40,7 +40,6 @@ fn rebalance_invest(){
       2000u32,
       test.defindex_protocol_receiver.clone(),
       2500u32,
-      test.defindex_factory.clone(),
       test.soroswap_router.address.clone(),
       name_symbol,
       true
@@ -139,7 +138,6 @@ fn rebalance_unwind(){
       2000u32,
       test.defindex_protocol_receiver.clone(),
       2500u32,
-      test.defindex_factory.clone(),
       test.soroswap_router.address.clone(),
       name_symbol,
       true
@@ -278,7 +276,6 @@ fn test_distribute_fees_auth(){
       2000u32,
       test.defindex_protocol_receiver.clone(),
       2500u32,
-      test.defindex_factory.clone(),
       test.soroswap_router.address.clone(),
       name_symbol,
       true
@@ -394,7 +391,6 @@ fn release_negative_or_zero_fees (){
       2000u32,
       test.defindex_protocol_receiver.clone(),
       2500u32,
-      test.defindex_factory.clone(),
       test.soroswap_router.address.clone(),
       name_symbol,
       true

--- a/apps/contracts/vault/src/test/vault/funds.rs
+++ b/apps/contracts/vault/src/test/vault/funds.rs
@@ -38,7 +38,6 @@ fn report_on_fetch_strategy_invested_funds() {
       2000u32,
       test.defindex_protocol_receiver.clone(),
       2500u32,
-      test.defindex_factory.clone(),
       test.soroswap_router.address.clone(),
       name_symbol,
       true

--- a/apps/contracts/vault/src/test/vault/get_asset_amounts_per_shares.rs
+++ b/apps/contracts/vault/src/test/vault/get_asset_amounts_per_shares.rs
@@ -45,7 +45,6 @@ fn deposit_several_assets_get_asset_amounts_per_shares() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -212,7 +211,6 @@ fn deposit_and_invest_several_assets_get_asset_amounts_per_shares() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true

--- a/apps/contracts/vault/src/test/vault/initialize.rs
+++ b/apps/contracts/vault/src/test/vault/initialize.rs
@@ -53,7 +53,6 @@ fn get_roles() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -168,7 +167,6 @@ fn deploy_unsupported_strategy() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -201,7 +199,6 @@ fn initialize_with_empty_asset_allocation() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -261,7 +258,6 @@ fn with_one_asset_and_several_strategies() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -355,7 +351,6 @@ fn with_one_asset_no_strategies(){
         1u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -458,7 +453,6 @@ fn initialize_with_excessive_vault_fee() {
         9500u32, // Fee greater than 9000 basis points (90%)
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -501,7 +495,6 @@ fn initialize_with_excessive_protocol_fee() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         9500u32, // Protocol fee greater than 9000 basis points (90%)
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -544,7 +537,6 @@ fn initialize_duplicated_asset_address(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -585,7 +577,6 @@ fn initialize_duplicated_strategy_address(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true

--- a/apps/contracts/vault/src/test/vault/rebalance.rs
+++ b/apps/contracts/vault/src/test/vault/rebalance.rs
@@ -44,7 +44,6 @@ fn multi_instructions() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -165,7 +164,6 @@ fn one_instruction() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -280,7 +278,6 @@ fn no_instructions() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -350,7 +347,6 @@ fn insufficient_balance() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -514,7 +510,6 @@ fn swap_exact_in() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -688,7 +683,6 @@ fn swap_exact_out() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -863,7 +857,6 @@ fn swap_from_unauthorized(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -952,7 +945,6 @@ fn swap_wrong_asset_in(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1029,7 +1021,6 @@ fn swap_wrong_asset_out(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1106,7 +1097,6 @@ fn invest_negative_amount(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1178,7 +1168,6 @@ fn invest_wrong_address(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1246,7 +1235,6 @@ fn invest_paused_strategy(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1344,7 +1332,6 @@ fn invest_more_than_idle_funds(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1414,7 +1401,6 @@ fn invest_unauthorized(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1496,7 +1482,6 @@ fn unwind_paused_strategy(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1603,7 +1588,6 @@ fn unwind_wrong_address(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1712,7 +1696,6 @@ fn unwind_negative_amount(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1823,7 +1806,6 @@ fn unwind_unauthorized(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1905,7 +1887,6 @@ fn unwind_over_max(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1997,7 +1978,6 @@ fn should_report(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true

--- a/apps/contracts/vault/src/test/vault/rescue.rs
+++ b/apps/contracts/vault/src/test/vault/rescue.rs
@@ -38,7 +38,6 @@ fn rescue_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true,
@@ -136,7 +135,6 @@ fn rescue_errors() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -210,7 +208,6 @@ fn pause_then_rescue() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -312,7 +309,6 @@ fn distribute_fees_on_rescue() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -429,7 +425,6 @@ fn should_report() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true,

--- a/apps/contracts/vault/src/test/vault/upgrade.rs
+++ b/apps/contracts/vault/src/test/vault/upgrade.rs
@@ -40,7 +40,6 @@ fn upgrade_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -93,7 +92,6 @@ fn upgrade_not_manager() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -145,7 +143,6 @@ fn upgrade_not_upgradable() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         false

--- a/apps/contracts/vault/src/test/vault/withdraw.rs
+++ b/apps/contracts/vault/src/test/vault/withdraw.rs
@@ -38,7 +38,6 @@ fn negative_amount() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -81,7 +80,6 @@ fn below_min() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -133,7 +131,6 @@ fn zero_total_supply() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -176,7 +173,6 @@ fn not_enough_balance() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -254,7 +250,6 @@ fn from_idle_one_asset_one_strategy_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -451,7 +446,6 @@ fn from_idle_two_assets_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -709,7 +703,6 @@ fn from_strategy_one_asset_one_strategy_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -802,7 +795,6 @@ fn from_strategies_one_asset_two_strategies_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -920,7 +912,6 @@ fn from_strategies_two_asset_each_one_strategy_success() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1296,7 +1287,6 @@ fn from_strategy_success_no_mock_all_auths() {
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true
@@ -1480,7 +1470,6 @@ fn unauthorized_withdraw(){
         2000u32,
         test.defindex_protocol_receiver.clone(),
         2500u32,
-        test.defindex_factory.clone(),
         test.soroswap_router.address.clone(),
         name_symbol,
         true


### PR DESCRIPTION
This pull request updates the factory and vault contracts to remove the defindex_factory parameter from the vault constructor. It also updates all tests to resolve #497