### PR TITLE
docs: update API docs for v0.3.0 breaking changes

### DIFF
--- a/apps/docs/advanced-documentation/sdks/02-defindex-sdk.md
+++ b/apps/docs/advanced-documentation/sdks/02-defindex-sdk.md
@@ -102,8 +102,8 @@ Here's a comprehensive example demonstrating vault creation, deposits, and withd
 import {
   DefindexSDK,
   SupportedNetworks,
-  CreateDefindexVault,
-  DepositToVaultParams,
+  CreateVaultParams,
+  DepositParams,
   WithdrawFromVaultParams
 } from '@defindex/sdk';
 
@@ -114,14 +114,14 @@ const sdk = new DefindexSDK({
 async function completeVaultFlow() {
   try {
     // 1. Create a new vault
-    const vaultConfig: CreateDefindexVault = {
+    const vaultConfig: CreateVaultParams = {
       roles: {
-        0: "GEMERGENCY_MANAGER_ADDRESS...", // Emergency Manager
-        1: "GFEE_RECEIVER_ADDRESS...",      // Fee Receiver
-        2: "GVAULT_MANAGER_ADDRESS...",     // Vault Manager
-        3: "GREBALANCE_MANAGER_ADDRESS..."  // Rebalance Manager
+        emergencyManager: "GEMERGENCY_MANAGER_ADDRESS...",
+        feeReceiver: "GFEE_RECEIVER_ADDRESS...",
+        manager: "GVAULT_MANAGER_ADDRESS...",
+        rebalanceManager: "GREBALANCE_MANAGER_ADDRESS..."
       },
-      vault_fee_bps: 100, // 1% fee (100 basis points)
+      vaultFeeBps: 100, // 1% fee (100 basis points)
       assets: [{
         address: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC", // XLM asset
         strategies: [{
@@ -130,10 +130,8 @@ async function completeVaultFlow() {
           paused: false
         }]
       }],
-      name_symbol: {
-        name: "My DeFi Vault", //Max 20 characters
-        symbol: "MDV"
-      },
+      name: "My DeFi Vault",  // 1-32 characters
+      symbol: "MDV",           // 1-10 characters
       upgradable: true,
       caller: "GCREATOR_ADDRESS..." // Public key of the signer account
     };
@@ -147,7 +145,7 @@ async function completeVaultFlow() {
 
     // 2. Deposit to vault
     const vaultAddress = 'CVAULT_CONTRACT_ADDRESS...';
-    const depositData: DepositToVaultParams = {
+    const depositData: DepositParams = {
       amounts: [1000000], // 1 XLM (7 decimals)
       caller: 'GUSER_ADDRESS...', // User's public key from which to sign and deposit
       invest: true, // Auto-invest after deposit
@@ -220,14 +218,14 @@ console.log('Factory contract:', factory.address);
 Deploy a new vault with custom configuration:
 
 ```typescript
-const vaultConfig: CreateDefindexVault = {
+const vaultConfig: CreateVaultParams = {
   roles: {
-    0: "GEMERGENCY_MANAGER...",  // Emergency Manager role
-    1: "GFEE_RECEIVER...",       // Fee Receiver role
-    2: "GVAULT_MANAGER...",      // Vault Manager role
-    3: "GREBALANCE_MANAGER..."   // Rebalance Manager role
+    emergencyManager: "GEMERGENCY_MANAGER...",
+    feeReceiver: "GFEE_RECEIVER...",
+    manager: "GVAULT_MANAGER...",
+    rebalanceManager: "GREBALANCE_MANAGER..."
   },
-  vault_fee_bps: 100,            // 1% vault fee
+  vaultFeeBps: 100,            // 1% vault fee
   assets: [{
     address: "CASSET_ADDRESS...", // Asset contract address
     strategies: [{
@@ -236,10 +234,8 @@ const vaultConfig: CreateDefindexVault = {
       paused: false
     }]
   }],
-  name_symbol: {
-    name: "Vault Name",
-    symbol: "VLT"
-  },
+  name: "Vault Name",
+  symbol: "VLT",
   upgradable: true,
   caller: "GCALLER_ADDRESS..."
 };
@@ -288,7 +284,7 @@ console.log(`Underlying Value: ${balance.underlyingBalance}`);
 Add funds to a vault:
 
 ```typescript
-const depositData: DepositToVaultParams = {
+const depositData: DepositParams = {
   amounts: [1000000, 2000000], // Amounts for each vault asset
   caller: userAddress,
   invest: true, // Automatically invest after deposit
@@ -382,22 +378,14 @@ await sdk.unpauseStrategy(vaultAddress, {
 Send signed XDR to the Stellar network:
 
 ```typescript
-// Submit via Stellar directly
 const response = await sdk.sendTransaction(
   signedXDR,
-  SupportedNetworks.TESTNET,
-  false // Don't use LaunchTube
+  SupportedNetworks.TESTNET
 );
 
-// Submit via LaunchTube
-const response = await sdk.sendTransaction(
-  signedXDR,
-  SupportedNetworks.TESTNET,
-  true // Use LaunchTube
-);
-
-console.log('Transaction hash:', response.hash);
-console.log('Status:', response.status);
+console.log('Transaction hash:', response.txHash);
+console.log('Success:', response.success);
+console.log('Result:', response.result);
 ```
 
 ***
@@ -498,9 +486,9 @@ import {
   DefindexSDK,
   DefindexSDKConfig,
   SupportedNetworks,
-  CreateDefindexVault,
-  DepositToVaultParams,
-  WithdrawFromVaultParams,
+  CreateVaultParams,
+  DepositParams,
+  WithdrawParams,
   VaultInfo,
   VaultBalance,
   VaultAPY

--- a/apps/docs/api-integration-guide/api.md
+++ b/apps/docs/api-integration-guide/api.md
@@ -134,8 +134,7 @@ Go to[ interact with vault](smart-contracts/), see the implementations of the fu
 
 ```javascript
 {
-    xdr: signedXdr,         // Signed transaction XDR
-    launchtube: false       // Set true for gasless transactions
+    xdr: signedXdr          // Signed transaction XDR
 }
 ```
 

--- a/apps/docs/api-integration-guide/guides-and-tutorials/beginner-guide.md
+++ b/apps/docs/api-integration-guide/guides-and-tutorials/beginner-guide.md
@@ -206,8 +206,7 @@ async function sendTransaction() {
 
         // Send the signed transaction
         const sendRequest = {
-            xdr: appState.signedTransaction,    // The signed transaction
-            launchtube: false                   // Use normal fees (not gasless)
+            xdr: appState.signedTransaction     // The signed transaction
         };
 
         const sendResult = await makeAPIRequest('/send', sendRequest);

--- a/apps/docs/api-integration-guide/guides-and-tutorials/setting-partner-fees.md
+++ b/apps/docs/api-integration-guide/guides-and-tutorials/setting-partner-fees.md
@@ -139,8 +139,7 @@ curl -X POST "https://api.defindex.io/send" \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "xdr": "SIGNED_XDR_HERE...",
-    "launchtube": false
+    "xdr": "SIGNED_XDR_HERE..."
   }'
 ```
 


### PR DESCRIPTION
## Summary
- Remove `launchtube` field from all send request examples (3 files)
- Update SDK type names (`CreateDefindexVault` → `CreateVaultParams`, `DepositToVaultParams` → `DepositParams`)
- Update vault roles from numeric indices to named keys (`emergencyManager`, `feeReceiver`, `manager`, `rebalanceManager`)
- Flatten `name_symbol` into separate `name` and `symbol` fields
- Fix `vault_fee_bps` → `vaultFeeBps`
- Update `sendTransaction` examples to use new response shape (`txHash`, `success` instead of `hash`, `status`)
- Remove LaunchTube references from SDK docs

## Context
These docs need to match the API v0.3.0 changes going live on April 20, 2026. Migration emails have already been sent to all integrators.

## Test plan
- [ ] Verify all code examples compile with `@defindex/sdk@0.3.0`
- [ ] Check GitBook renders correctly