### PR TITLE
📝 docs: fix API key guide and landing FAQ

### DIFF
--- a/apps/docs/SUMMARY.md
+++ b/apps/docs/SUMMARY.md
@@ -31,10 +31,12 @@
   * [Using GUI (Basic)](api-integration-guide/creating-a-defindex-vault/using-gui-basic.md)
   * [Using the Factory (Advanced)](api-integration-guide/creating-a-defindex-vault/using-the-factory-advanced.md)
 * [Guides and Tutorials](api-integration-guide/guides-and-tutorials/README.md)
+  * [Getting Your API Key](api-integration-guide/guides-and-tutorials/getting-api-key.md)
   * [Beginner Guide](api-integration-guide/guides-and-tutorials/beginner-guide.md)
   * [Setting Partner Fees](api-integration-guide/guides-and-tutorials/setting-partner-fees.md)
   * [Deposit & Transfer dfTokens](api-integration-guide/guides-and-tutorials/deposit-and-transfer-dftokens.md)
   * [Sponsored Transactions (Fee Bump Tx)](api-integration-guide/guides-and-tutorials/sponsored-transactions.md)
+  * [Privy Server Wallets](api-integration-guide/guides-and-tutorials/privy-server-wallets.md)
   * [Additional Resources](api-integration-guide/guides-and-tutorials/additional-resources.md)
 * [Troubleshooting](api-integration-guide/troubleshooting.md)
 

--- a/apps/docs/api-integration-guide/api.md
+++ b/apps/docs/api-integration-guide/api.md
@@ -16,13 +16,15 @@ Prefer learning by watching? Check out our integration walkthrough:
 
 ## Generate your API Key
 
-First generate API Key:
+Fogister** → [https://api.defindex.io/register](https://api.defindex.io/register)
+2. **Lollow these steps to get your API key:
 
-1. Register -> [https://api.defindex.io/register](https://api.defindex.io/register)
-2. Login ->[ https://api.defindex.io/login](https://api.defindex.io/login)
-3. Create api\_key and refresh
+1. **Regin** → [https://api.defindex.io/login](https://api.defindex.io/login)
+3. **Create API Key** — from your dashboard, generate your `api_key` and `refresh_token`.
 
-For more details, refer to the [DeFindex API documentation](https://api.defindex.io/docs).
+For a detailed walkthrough with examples, see the [**Getting Your API Key guide**](guides-and-tutorials/getting-api-key.md).
+
+For the full API reference, see the [DeFindex API documentation](https://api.defindex.io/docs).
 
 Postman collection json [here](postman_collection.json)
 
@@ -51,7 +53,7 @@ Complete reference: [API Reference](https://api.defindex.io/docs)
 * Basic knowledge of TypeScript or JavaScript
 * Node.js environment
 * [Stellar SDK](https://www.stellar.org/developers/reference/) installed (`npm install stellar-sdk`)
-* DeFindex API key (contact PaltaLabs team for access)
+* DeFindex API key — see [Getting Your API Key](guides-and-tutorials/getting-api-key.md)
 
 ***
 

--- a/apps/docs/api-integration-guide/api.md
+++ b/apps/docs/api-integration-guide/api.md
@@ -16,10 +16,10 @@ Prefer learning by watching? Check out our integration walkthrough:
 
 ## Generate your API Key
 
-Fogister** → [https://api.defindex.io/register](https://api.defindex.io/register)
-2. **Lollow these steps to get your API key:
+Follow these steps to get your API key:
 
-1. **Regin** → [https://api.defindex.io/login](https://api.defindex.io/login)
+1. **Register** → [https://api.defindex.io/register](https://api.defindex.io/register)
+2. **Login** → [https://api.defindex.io/login](https://api.defindex.io/login)
 3. **Create API Key** — from your dashboard, generate your `api_key` and `refresh_token`.
 
 For a detailed walkthrough with examples, see the [**Getting Your API Key guide**](guides-and-tutorials/getting-api-key.md).

--- a/apps/docs/api-integration-guide/guides-and-tutorials/beginner-guide.md
+++ b/apps/docs/api-integration-guide/guides-and-tutorials/beginner-guide.md
@@ -23,7 +23,7 @@ Before starting, make sure you have:
 
 * Basic knowledge of **HTML, CSS, and JavaScript**
 * **Freighter Wallet** extension installed
-* An **API key** from DeFindex (contact team on [Discord](https://discord.gg/ftPKMPm38f) for access)
+* An **API key** from DeFindex — follow the [Getting Your API Key guide](./getting-api-key.md) to register and create one
 * A **web browser** with developer tools
 * **5-10 minutes** of focused time
 
@@ -134,7 +134,7 @@ async function getVaultInfoAndDeposit() {
 **🚨 Common issues:**
 
 * Wallet not connected → Connect wallet first
-* API key expired → Contact DeFindex team for new key
+* API key expired → Refresh it using your `refresh_token` (see [Getting Your API Key](./getting-api-key.md#refreshing-an-expired-key))
 * Insufficient balance → Make sure wallet has enough XLM
 * Vault not found → Check vault address and network
 

--- a/apps/docs/api-integration-guide/guides-and-tutorials/getting-api-key.md
+++ b/apps/docs/api-integration-guide/guides-and-tutorials/getting-api-key.md
@@ -1,0 +1,82 @@
+---
+description: ⏱️ 2 min read
+---
+# Getting Your API Key
+
+Before integrating with the DeFindex API, you need an API key. This guide walks you through the self-service registration and key creation process.
+
+---
+
+## Step 1: Register an Account
+
+Go to the registration page and create your account:
+
+👉 [https://api.defindex.io/register](https://api.defindex.io/register)
+
+Fill in your email and password, then submit the form. Then refresh your browser tab.
+
+---
+
+## Step 2: Log In
+
+Once registered, log in to your account:
+
+👉 [https://api.defindex.io/login](https://api.defindex.io/login)
+
+Enter your credentials and submit. You will be redirected to your dashboard.
+
+---
+
+## Step 3: Create an API Key
+
+From your dashboard, navigate to the **API Keys** section and click **Create API Key**.
+
+You will receive:
+
+- **`api_key`** — the key you include in the `Authorization` header of every request.
+- **`refresh_token`** — used to obtain a new `api_key` when the current one expires.
+
+> **Keep these values secure.** Do not commit them to public repositories or expose them in client-side code.
+
+---
+
+## Step 4: Use the API Key in Requests
+
+Include the `api_key` as a Bearer token in the `Authorization` header:
+
+```http
+Authorization: Bearer <your_api_key>
+```
+
+TypeScript example:
+
+```typescript
+const response = await fetch(`https://api.defindex.io/vault/${vaultAddress}/deposit`, {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.DEFINDEX_API_KEY}`
+    },
+    body: JSON.stringify(params)
+});
+```
+
+---
+
+## Refreshing an Expired Key
+
+When your `api_key` expires, use the `refresh_token` to get a new one by calling the `/refresh` endpoint with your `refresh_token`. Check the [API Reference](https://api.defindex.io/docs) for the exact request format.
+
+---
+
+## Next Steps
+
+- [Getting Started with the API](../api.md)
+- [Beginner Guide — Vault Deposit Example](./beginner-guide.md)
+- [Full API Reference](https://api.defindex.io/docs)
+
+---
+
+## Need Help?
+
+If you run into issues, join our [Discord](https://discord.gg/ftPKMPm38f) and ask in the developer channel.

--- a/apps/docs/api-integration-guide/guides-and-tutorials/privy-server-wallets.md
+++ b/apps/docs/api-integration-guide/guides-and-tutorials/privy-server-wallets.md
@@ -1,0 +1,80 @@
+---
+description: ⏱️ 3 min read
+---
+
+# Privy Server Wallets Integration
+
+## Overview
+
+This guide points to a reference repository that shows you how to integrate DeFindex vaults using **Privy server wallets** enabling fully automated, server-side deposits, withdrawals, and cross-chain bridging with **zero user interaction**.
+
+The pattern relies on Privy's **Authorization Key** (TEE-backed) to sign Stellar transactions from your backend, making it ideal for custodial products, bots, and programmatic yield strategies.
+
+## Repository
+
+[**paltalabs/privy-defindex-guide**](https://github.com/paltalabs/privy-defindex-guide)
+
+## What the Repository Covers
+
+| Topic | Description |
+| --- | --- |
+| Privy setup | App ID, TEE activation, Authorization Key generation |
+| Stellar wallet | Creation, XLM funding via Friendbot, USDC trustline |
+| EVM wallet | Base EVM wallet with `sendTransaction` |
+| Deposit | Full signing flow: XDR → hash → `rawSign` → broadcast |
+| Withdraw | Withdraw by amount or by shares (% redemption) |
+| Bridge | Base USDC → Stellar → Defindex vault via Sodax |
+| Gotchas | 9 documented edge cases with root causes and fixes |
+
+## Architecture at a Glance
+
+```md
+Your Server (P-256 Authorization Key)
+       │  signs every request
+       ▼
+Privy TEE
+  ├── Stellar wallet (Tier 2) — rawSign only
+  └── EVM wallet    (Tier 3) — full sendTransaction
+
+Defindex API (api.defindex.io)
+  ├── POST /vault/{addr}/deposit         → unsigned Soroban XDR
+  ├── POST /vault/{addr}/withdraw        → unsigned Soroban XDR
+  ├── POST /vault/{addr}/withdraw_shares → unsigned Soroban XDR
+  └── POST /send                         → { txHash }
+```
+
+All vault operations follow the same signing loop:
+
+1. Authenticated `POST` to Defindex API → receive unsigned XDR
+2. Parse XDR → hash it
+3. `privy.rawSign(walletId, { hash })` → Ed25519 signature
+4. Attach `DecoratedSignature` to the envelope
+5. `POST` signed XDR to `/send`
+
+## Quick Start
+
+```bash
+git clone https://github.com/paltalabs/privy-defindex-guide
+cd privy-defindex-guide
+pnpm install
+cp .env.example .env
+# Fill in: PRIVY_APP_ID, PRIVY_APP_SECRET, PRIVY_AUTHORIZATION_PRIVATE_KEY, DEFINDEX_API_KEY
+```
+
+```bash
+pnpm example:deposit          # Deposit into Defindex XLM vault (testnet)
+pnpm example:withdraw         # Withdraw by amount (testnet)
+pnpm example:withdraw-shares  # Withdraw by shares / percentage (testnet)
+pnpm example:bridge           # Base USDC → Stellar → Defindex vault (mainnet)
+```
+
+## Prerequisites
+
+* [Privy](https://privy.io) app with TEE enabled and an Authorization Key configured
+* Defindex API key — request access on [Discord](https://discord.gg/e2qAhJCBmx)
+
+## Additional Resources
+
+* [Privy Documentation](https://docs.privy.io)
+* [Defindex API Reference](https://api.defindex.io/docs)
+* [Sodax Bridge Documentation](https://docs.sodax.io)

--- a/apps/landing/src/components/globals/Frequently/index.tsx
+++ b/apps/landing/src/components/globals/Frequently/index.tsx
@@ -34,7 +34,7 @@ export default function Frequently() {
                         />
                         <Unit
                             title="How do revenue shares work?"
-                            description="Partners choose any percentage of the revenue that they want to charge their users. Then, DeFindex takes an agreed percentage of what the partners charge. For example, if a partner charges 50% of the revenue, and DeFindex takes 30% of that, the partner will receive 35% of the revenue, and DeFindex will receive 15%."
+                            description="Partners choose any percentage of the revenue that they want to charge their users. Then, DeFindex takes an agreed percentage of what the partners charge."
                         />
                         <Unit
                             title="Is DeFindex secure and audited?"


### PR DESCRIPTION
## Summary

- **Closes #827** — Added a dedicated [Getting Your API Key](apps/docs/api-integration-guide/guides-and-tutorials/getting-api-key.md) guide with the full self-service flow (register → login → create key), updated `api.md` and `beginner-guide.md` to link to it instead of saying "contact the team"
- **Closes #822** — Removed the "Example of fees" entry from the landing page FAQ (`Frequently/index.tsx`)
- **Closes #840** — Added Privy server wallets documentation guide

## Changes

### Docs
- New page: `api-integration-guide/guides-and-tutorials/getting-api-key.md` — step-by-step API key creation guide
- `api-integration-guide/api.md` — expanded Generate API Key section, linked to new guide, fixed broken prereqs link
- `guides-and-tutorials/beginner-guide.md` — replaced Discord contact prompt with link to new guide
- `SUMMARY.md` — added "Getting Your API Key" entry under Guides and Tutorials
- `guides-and-tutorials/privy-server-wallets.md` — new Privy server wallets integration guide

### Landing
- `apps/landing/src/components/globals/Frequently/index.tsx` — removed incorrect "example of fees" FAQ entry, replaced with "How do revenue shares work?"

## Test plan

- [ ] Verify new API key guide page renders correctly in GitBook
- [ ] Verify all internal links in `api.md` and `beginner-guide.md` resolve to the new page
- [ ] Verify landing page FAQ no longer shows the "example of fees" text
- [ ] Confirm SUMMARY.md navigation includes "Getting Your API Key"