### PR TITLE
📝 docs: Add Crossmint Smart Wallets integration guide

### DIFF
--- a/apps/docs/SUMMARY.md
+++ b/apps/docs/SUMMARY.md
@@ -37,6 +37,7 @@
   * [Deposit & Transfer dfTokens](api-integration-guide/guides-and-tutorials/deposit-and-transfer-dftokens.md)
   * [Sponsored Transactions (Fee Bump Tx)](api-integration-guide/guides-and-tutorials/sponsored-transactions.md)
   * [Privy Server Wallets](api-integration-guide/guides-and-tutorials/privy-server-wallets.md)
+  * [Crossmint Smart Wallets](api-integration-guide/guides-and-tutorials/crossmint-smart-wallets.md)
   * [Additional Resources](api-integration-guide/guides-and-tutorials/additional-resources.md)
 * [Troubleshooting](api-integration-guide/troubleshooting.md)
 

--- a/apps/docs/api-integration-guide/guides-and-tutorials/crossmint-smart-wallets.md
+++ b/apps/docs/api-integration-guide/guides-and-tutorials/crossmint-smart-wallets.md
@@ -1,0 +1,87 @@
+---
+description: ⏱️ 3 min read
+---
+
+# Crossmint Smart Wallets Integration
+
+## Overview
+
+This guide points to a reference repository that shows you how to integrate DeFindex vaults using **Crossmint smart wallets** — enabling fully automated, server-side deposits, withdrawals, and cross-chain bridging with **zero user interaction**.
+
+The pattern uses an **EVM private key registered as `adminSigner`** to control both an ERC-4337 smart wallet on Base and a Stellar smart wallet. All Defindex vault interactions go through Crossmint's REST API as Soroban `contract-call` transactions — no manual XDR construction required.
+
+## Repository
+
+[**defindex-io/crossmint-defindex-guide**](https://github.com/defindex-io/crossmint-defindex-guide)
+
+## What the Repository Covers
+
+| Topic | Description |
+| --- | --- |
+| Crossmint setup | Server API key (`sk_`), wallet email, staging vs production |
+| EVM wallet | ERC-4337 smart wallet on Base with `external-wallet` adminSigner |
+| Stellar wallet | Stellar smart wallet with auto-XLM funding, Soroban contract-call signing |
+| Deposit | `contract-call` via Crossmint REST → base64 XDR approval → poll |
+| Withdraw | Withdraw by amount or by shares (% redemption) |
+| Bridge | Base USDC → Stellar → Defindex vault via Sodax |
+| Gotchas | 9 documented edge cases with root causes and fixes |
+
+## Architecture at a Glance
+
+```
+Your Server (EVM Private Key as adminSigner)
+       │
+       ▼
+Crossmint REST API (api/2025-06-09)
+  ├── EVM Smart Wallet (ERC-4337, Base)
+  │     POST /transactions → sign hex bytes → POST /approvals → onChain.txId
+  └── Stellar Smart Wallet
+        POST /transactions (contract-call) → sign base64 XDR → POST /approvals → onChain.txId
+
+Sodax Bridge
+  └── Base USDC → Stellar USDC (via Sonic hub, no Horizon polling needed)
+
+Defindex Vault (Soroban)
+  ├── method: deposit         → amounts_desired, amounts_min, from, invest
+  ├── method: withdraw        → amounts_to_withdraw, from
+  └── method: withdraw_shares → shares_amount, from
+```
+
+All vault operations follow the same pattern:
+
+1. `POST` to Crossmint REST → create `contract-call` transaction
+2. Response is `awaiting-approval` with a base64-encoded XDR message
+3. Sign with `keypair.sign(Buffer.from(message, "base64"))` using `STELLAR_SERVER_KEY`
+4. `POST` signature to `/approvals`
+5. Poll until `onChain.txId` is returned
+
+## Quick Start
+
+```bash
+git clone https://github.com/defindex-io/crossmint-defindex-guide
+cd crossmint-defindex-guide
+pnpm install
+cp .env.example .env
+# Fill in: CROSSMINT_SERVER_API_KEY (sk_...), CROSSMINT_WALLET_EMAIL,
+#          EVM_PRIVATE_KEY, STELLAR_SERVER_KEY
+```
+
+```bash
+CROSSMINT_ENV=staging pnpm example:deposit          # Deposit into testnet vault
+CROSSMINT_ENV=staging pnpm example:withdraw         # Withdraw by amount (testnet)
+CROSSMINT_ENV=staging pnpm example:withdraw-shares  # Withdraw by shares (testnet)
+CROSSMINT_ENV=production pnpm example:bridge        # Base USDC → Stellar → Defindex vault (mainnet)
+```
+
+## Prerequisites
+
+* [Crossmint](https://crossmint.com) account with a **server API key** (must start with `sk_`, not `ck_`)
+* `EVM_PRIVATE_KEY` — becomes the `adminSigner` of the EVM smart wallet on Base
+* `STELLAR_SERVER_KEY` — Stellar ed25519 secret key, becomes the `adminSigner` of the Stellar wallet
+* Defindex API key — request access on [Discord](https://discord.gg/e2qAhJCBmx)
+
+## Additional Resources
+
+* [Crossmint Documentation](https://docs.crossmint.com)
+* [Defindex API Reference](https://api.defindex.io/docs)
+* [Sodax Bridge Documentation](https://docs.sodax.io)

--- a/apps/docs/api-integration-guide/guides-and-tutorials/privy-server-wallets.md
+++ b/apps/docs/api-integration-guide/guides-and-tutorials/privy-server-wallets.md
@@ -12,7 +12,7 @@ The pattern relies on Privy's **Authorization Key** (TEE-backed) to sign Stellar
 
 ## Repository
 
-[**paltalabs/privy-defindex-guide**](https://github.com/paltalabs/privy-defindex-guide)
+[**defindex-io/privy-defindex-guide**](https://github.com/defindex-io/privy-defindex-guide)
 
 ## What the Repository Covers
 


### PR DESCRIPTION
## Summary

- Adds a new tutorial page documenting how to integrate DeFindex vaults using **Crossmint smart wallets** (ERC-4337 on Base + Stellar smart wallet)
- Registers the new page in `SUMMARY.md` so it appears in the docs sidebar
- Updates the Privy guide repository link from `paltalabs/` to `defindex-io/`

## What's covered in the new guide

- Architecture overview: EVM private key as `adminSigner` controlling both EVM and Stellar smart wallets via Crossmint REST API
- Deposit, withdraw, and bridge flows
- Quick start commands for staging and production
- 9 documented gotchas with root causes and fixes (in the reference repo)

## Test plan

- [ ] Verify the new page renders correctly in the docs site
- [ ] Check that the sidebar entry in `SUMMARY.md` links correctly to the new file
- [ ] Confirm the updated Privy guide repo URL (`defindex-io/privy-defindex-guide`) is accessible