### PR TITLE
docs: clarify vault creation requirements (network, tokens, args)

### DIFF
--- a/apps/docs/api-integration-guide/creating-a-defindex-vault/README.md
+++ b/apps/docs/api-integration-guide/creating-a-defindex-vault/README.md
@@ -30,7 +30,7 @@ DeFindex operates on **Stellar Mainnet** and **Stellar Testnet**. The two networ
 
 **On Testnet**, DeFindex strategies use a test USDC issued by the Blend Capital testnet deployment — referred to here as **BlendUSDC**. This is **not** Soroswap or regular USDC; it is a separate test token you must obtain from [testnet.blend.capital](https://testnet.blend.capital).
 
-**On Mainnet**, strategies use real USDC (Circle) and other well known tokens.
+**On Mainnet**, strategies use real USDC (Circle) and other well-known tokens.
 
 
 #### Token addresses
@@ -65,8 +65,7 @@ You need testnet tokens to deploy and interact with a vault on testnet:
 
 A **minimum first deposit of 1001 units** (in the asset's smallest denomination — stroops) of your vault's underlying asset is required immediately after deployment.
 
-* **1 unit is permanently locked** in the vault as an inflation-attack defense mechanism.
-* **1000 units** represent the effective minimum deposit.
+* On the **first deposit**, the vault locks **1000 shares** as an inflation-attack defense mechanism.
 * **Example**: For a USDC vault (7 decimals), 1001 stroops = **0.0001001 USDC** — practically free.
 * **Example**: For an XLM vault (7 decimals), 1001 stroops = **0.0001001 XLM** — also negligible.
 

--- a/apps/docs/api-integration-guide/creating-a-defindex-vault/README.md
+++ b/apps/docs/api-integration-guide/creating-a-defindex-vault/README.md
@@ -7,7 +7,72 @@ description: ⏱️ 3 min read
 # Create a Vault
 
 DeFindex Vaults let **wallet builders** design yield products tailored to their users.\
-With a vault, you choose the **assets**, **strategies**, **allocation**, and **fees**—and you can rebalance positions or rescue funds at any time. From the end-user’s perspective, it’s just **deposit and withdraw**.
+With a vault, you choose the **assets**, **strategies**, **allocation**, and **fees**—and you can rebalance positions or rescue funds at any time. From the end-user's perspective, it's just **deposit and withdraw**.
+
+***
+
+## Vault Creation Requirements
+
+Before you deploy a vault, make sure you meet the following requirements. These details are often the source of confusion for new builders.
+
+### Network
+
+DeFindex operates on **Stellar Mainnet** and **Stellar Testnet**. The two networks are completely independent and use different contract addresses and token types.
+
+| Requirement | Testnet | Mainnet |
+|---|---|---|
+| Network Passphrase | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| Factory contract | See [Testnet Deployment](../../contract-deployments/testnet-deployment.md) | See [Mainnet Deployment](../../contract-deployments/mainnet-deployment.md) |
+| RPC URL | `https://soroban-testnet.stellar.org` | `https://soroban.stellar.org` or another provider |
+| Horizon URL | `https://horizon-testnet.stellar.org` | `https://horizon.stellar.org` |
+
+### Tokens
+
+**On Testnet**, DeFindex strategies use a test USDC issued by the Blend Capital testnet deployment — referred to here as **BlendUSDC**. This is **not** Soroswap or regular USDC; it is a separate test token you must obtain from [testnet.blend.capital](https://testnet.blend.capital).
+
+**On Mainnet**, strategies use real USDC (Circle) and other well known tokens.
+
+
+#### Token addresses
+
+| Token | Network | Contract Address |
+|---|---|---|
+| XLM (native SAC) | Testnet & Mainnet | `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` |
+| BlendUSDC | **Testnet only** | `CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU` |
+| USDC (Circle) | **Mainnet only** | `CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75` |
+| CETES | Testnet | `CC72F57YTPX76HAA64JQOEGHQAPSADQWSY5DWVBR66JINPFDLNCQYHIC` |
+
+For a full list of deployed strategy contract addresses, see the [Contract Deployments](../../contract-deployments/) section.
+
+### Getting Testnet Tokens
+
+You need testnet tokens to deploy and interact with a vault on testnet:
+
+1. **XLM (for fees)**: Use [Friendbot](https://friendbot.stellar.org/) to fund your testnet account.
+   ```
+   https://friendbot.stellar.org/?addr=YOUR_STELLAR_ADDRESS
+   ```
+2. **BlendUSDC** (required for USDC vaults on testnet):
+   - Go to [testnet.blend.capital](https://testnet.blend.capital).
+   - Connect your Freighter wallet (switch to Testnet in wallet settings first).
+   - Click **"Faucet"** or use the asset menu to add a BlendUSDC trustline and receive test tokens.
+3. **CETES** (required for CETES vaults on testnet):
+   - Contact Etherfuse team to get the official test CETES
+
+> **Why BlendUSDC?** On testnet, DeFindex strategies are deployed against the Blend Capital testnet pools, which use their own test USDC. Real Circle USDC does not support large amounts minting on Stellar Testnet.
+
+### Funding Requirements
+
+A **minimum first deposit of 1001 units** (in the asset's smallest denomination — stroops) of your vault's underlying asset is required immediately after deployment.
+
+* **1 unit is permanently locked** in the vault as an inflation-attack defense mechanism.
+* **1000 units** represent the effective minimum deposit.
+* **Example**: For a USDC vault (7 decimals), 1001 stroops = **0.0001001 USDC** — practically free.
+* **Example**: For an XLM vault (7 decimals), 1001 stroops = **0.0001001 XLM** — also negligible.
+
+This is required to prevent the [ERC-4626 inflation attack](https://blog.openzeppelin.com/a-novel-defense-against-erc4626-inflation-attacks) (the same class of attack applies to Soroban vaults).
+
+> Funds are **not** automatically invested on deposit. After the first deposit you must perform a [**first rebalance**](#step-5-first-rebalance) to allocate funds across strategies.
 
 ***
 
@@ -15,10 +80,12 @@ With a vault, you choose the **assets**, **strategies**, **allocation**, and **f
 
 Before deployment, you must configure the following **roles** (each tied to an address):
 
-* **Vault Manager** – primary owner, manages settings, upgrades, and other roles (_use a multisig for security_)
+* **Manager** – primary owner, manages settings, upgrades, and other roles (_use a multisig for security_)
+* **Emergency Manager** – rescues funds and pauses risky strategies (_automate for faster response_)
 * **Rebalance Manager** – allocates funds across strategies (_can be automated, or managed by a third party_)
 * **Fee Receiver** – collects performance fees (_use a secure, dedicated wallet_)
-* **Emergency Manager** – rescues funds and pauses risky strategies (_automate for faster response_)
+
+> All four roles must be assigned. You may use the same address for multiple roles, but this is not recommended for production.
 
 ***
 
@@ -26,13 +93,14 @@ Before deployment, you must configure the following **roles** (each tied to an a
 
 * Fees are expressed in **basis points** (1 bp = 0.01%).
 * The **Vault Fee** is applied to strategy earnings and assigned to the Fee Receiver.
+* Maximum allowed fee: **10,000 bps (100%)** — in practice, keep this well below 100%.
 
 ***
 
 **Upgradability**
 
 * You may choose whether the vault contract is **upgradable**.
-* If enabled, the contract’s WASM code can be updated **without user signatures**.
+* If enabled, the Manager can update the contract's WASM code **without user signatures**.
 * This allows improvements or bug fixes without interrupting vault operations.
 
 ***
@@ -45,7 +113,9 @@ DeFindex offers **curated and audited strategies**, currently live for:
 * **Blend Autocompound – YieldBlox Pool**: USDC, EURC, XLM, CETES, USTRY, AQUA
 * **Blend Autocompound – Orbit Pool**: XLM, CETES, USTRY, oUSD
 
-👉 Need support for additional pools? Just ping us.
+Each vault supports one or more assets, and each asset can be backed by one or more strategies.
+
+> Need support for additional pools? Just ping us on [Discord](https://discord.gg/e2qAhJCBmx).
 
 ***
 
@@ -54,9 +124,9 @@ DeFindex offers **curated and audited strategies**, currently live for:
 You can deploy your Vault in two ways:
 
 * [**Using GUI (Basic)**](using-gui-basic.md)
-* [Using the Factory Contract (Advanced)](using-the-factory-advanced.md)
+* [**Using the Factory Contract or API (Advanced)**](using-the-factory-advanced.md)
 
-### Step 4: Do a First Deposit&#x20;
+### Step 4: Do a First Deposit
 
 A **minimum first deposit of 1001 units** of your supported asset is required.
 

--- a/apps/docs/api-integration-guide/creating-a-defindex-vault/using-the-factory-advanced.md
+++ b/apps/docs/api-integration-guide/creating-a-defindex-vault/using-the-factory-advanced.md
@@ -12,7 +12,7 @@ This guide documents every argument involved in deploying a DeFindex vault — w
 
 ### Testnet
 
-Testnet addresses may be not valid after June 17 or December 16 of 2026 testnet resets. if that is the case let us know via Discord to update the docs.
+Testnet addresses may be not valid after the June 17 or December 16, 2026, testnet resets. If that's the case let us know via Discord so we can update the docs.
 
 | Contract | Address |
 |---|---|

--- a/apps/docs/api-integration-guide/creating-a-defindex-vault/using-the-factory-advanced.md
+++ b/apps/docs/api-integration-guide/creating-a-defindex-vault/using-the-factory-advanced.md
@@ -1,50 +1,534 @@
 ---
-description: ⏱️ 2 min read
+description: ⏱️ 5 min read
 ---
+
 # Using the Factory (Advanced)
 
-If you prefer to interact directly with the DeFindex Factory contract to create a vault, here's a step-by-step guide:
+This guide documents every argument involved in deploying a DeFindex vault — whether you call the factory smart contract directly or use the DeFindex REST API. Read the [Vault Creation Requirements](README.md#vault-creation-requirements) section first before proceeding.
 
-1. **Locate the Factory contract**: Find the DeFindex Factory contract address in the [`~/public/`](https://github.com/paltalabs/defindex/tree/main/public) folder.
-2. **Prepare the transaction**: Use your preferred method to prepare a transaction that interacts with the Factory contract. You will need to provide the following parameters:
-   * `roles`: A `Map` containing role identifiers (`u32`) and their respective addresses (`Address`). Example: `{1: "GCINP...", 2: "GCINP..."}`.
-   * `vault_fee`: The commission rate in basis points (1 basis point = 0.01%). Example: `100` for a 1% fee.
-   * `assets`: A vector of [`AssetStrategySet`](../../../contracts/common/src/models.rs) structures that define the strategies and assets managed by the vault.
-     *   **Structure of AssetStrategySet**:
+---
 
-         ```rust
-         struct AssetStrategySet {
-             address: Address,  // The address of the asset (token)
-             strategies: Vec<Strategy>,  // A vector of strategies for this asset
-         }
+## Quick Reference: Contract Addresses
 
-         struct Strategy {
-             address: Address,  // The address of the strategy contract
-             name: String,      // The name of the strategy
-             paused: bool,      // Whether the strategy is initially paused
-         }
-         ```
-     *   **Example**:
+### Testnet
 
-         ```json
-         {
-           "address": "CBZ5WXLMCH...",  // USDC token address
-           "strategies": [
-             {
-               "address": "CCIN4WQP5Z...",  // Lending strategy address
-               "name": "DummyStrategy",
-               "paused": false
-             },
-             {
-               "address": "CD2QVXMN7Y...",  // Yield farming strategy address
-               "name": "DummyStrategy2",
-               "paused": false
-             }
-           ]
-         }
-         ```
-   * `soroswap_router`: The address of the Soroswap router (`Address`) that facilitates exchanges within the vault. (You can find the address [here](https://api.soroswap.finance/api/mainnet/router))
-   * `name_symbol`: A `Map` containing the name and symbol of the vault. Example: `{"name": "MyVault", "symbol": "MVLT"}`.
-   * `upgradable`: A boolean indicating whether the vault contract will support upgrades. Example: `true` or `false`.
-3. **Submit the transaction**: Once you have prepared the transaction with the required parameters, sign and send it using your preferred method.
-4. **Wait for confirmation**: After submitting the transaction, wait for it to be confirmed on the blockchain. Once confirmed, your vault will be active, and you can start interacting with it.
+Testnet addresses may be not valid after June 17 or December 16 of 2026 testnet resets. if that is the case let us know via Discord to update the docs.
+
+| Contract | Address |
+|---|---|
+| Factory | `CDSCWE4GLNBYYTES2OCYDFQA2LLY4RBIAX6ZI32VSUXD7GO6HRPO4A32` |
+| Soroswap Router | `CCJUD55AG6W5HAI5LRVNKAE5WDP5XGZBUDS5WNTIVDU7O264UZZE7BRD` |
+| XLM (native SAC) | `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` |
+| BlendUSDC | `CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU` |
+| CETES token | `CC72F57YTPX76HAA64JQOEGHQAPSADQWSY5DWVBR66JINPFDLNCQYHIC` |
+| USDC Blend Strategy | `CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY` |
+| XLM Blend Strategy | `CDVLOSPJPQOTB6ZCWO5VSGTOLGMKTXSFWYTUP572GTPNOWX4F76X3HPM` |
+| CETES Blend Strategy | `CCP4RBDWPRNO2LWO23XFU4BBLGA73J5N3BK7EHRJUHVN33YEMMFB2MBE` |
+
+### Mainnet
+
+| Contract | Address |
+|---|---|
+| Factory | `CDKFHFJIET3A73A2YN4KV7NSV32S6YGQMUFH3DNJXLBWL4SKEGVRNFKI` |
+| Soroswap Router | See [api.soroswap.finance/api/mainnet/router](https://api.soroswap.finance/api/mainnet/router) |
+| XLM (native SAC) | `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` |
+| USDC (Circle) | `CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75` |
+| USDC Fixed Pool Strategy | `CDB2WMKQQNVZMEBY7Q7GZ5C7E7IAFSNMZ7GGVD6WKTCEWK7XOIAVZSAP` |
+| EURC Fixed Pool Strategy | `CC5CE6MWISDXT3MLNQ7R3FVILFVFEIH3COWGH45GJKL6BD2ZHF7F7JVI` |
+| XLM Fixed Pool Strategy | `CDPWNUW7UMCSVO36VAJSQHQECISPJLCVPDASKHRC5SEROAAZDUQ5DG2Z` |
+| USDC YieldBlox Strategy | `CCSRX5E4337QMCMC3KO3RDFYI57T5NZV5XB3W3TWE4USCASKGL5URKJL` |
+| XLM YieldBlox Strategy | `CBDOIGFO2QOOZTWQZ7AFPH5JOUS2SBN5CTTXR665NHV6GOCM6OUGI5KP` |
+| CETES YieldBlox Strategy | `CBTSRJLN5CVVOWLTH2FY5KNQ47KW5KKU3VWGASDN72STGMXLRRNHPRIL` |
+
+For the complete list of mainnet strategies, see [Mainnet Deployment](../../contract-deployments/mainnet-deployment.md).
+
+---
+
+## Vault Role IDs
+
+When calling the factory contract directly, roles are passed as a `Map<u32, Address>`. The role IDs are:
+
+| ID | Role | Description |
+|---|---|---|
+| `0` | Emergency Manager | Can pause strategies and rescue funds in emergencies |
+| `1` | Fee Receiver | Receives vault performance fees |
+| `2` | Manager | Full administrative control over the vault |
+| `3` | Rebalance Manager | Can rebalance asset allocations across strategies |
+
+All four roles must be assigned. The same address can be used for multiple roles.
+
+---
+
+## Method 1: Direct Factory Contract Call
+
+Use this method when integrating at the smart-contract level (e.g., building your own deployment script or using `stellar-cli`).
+
+### Function: `create_defindex_vault`
+
+```rust
+fn create_defindex_vault(
+    e: Env,
+    roles: Map<u32, Address>,
+    vault_fee: u32,
+    assets: Vec<AssetStrategySet>,
+    soroswap_router: Address,
+    name_symbol: Map<String, String>,
+    upgradable: bool,
+) -> Result<Address, FactoryError>
+```
+
+#### Parameter Reference
+
+| Parameter | Type | Description |
+|---|---|---|
+| `roles` | `Map<u32, Address>` | Maps role IDs (0–3) to Stellar addresses. All four roles are required. |
+| `vault_fee` | `u32` | Vault fee in basis points (1 bps = 0.01%). Max: 10,000 (100%). |
+| `assets` | `Vec<AssetStrategySet>` | The assets the vault manages and their associated strategies. |
+| `soroswap_router` | `Address` | Address of the Soroswap router used for internal swaps. |
+| `name_symbol` | `Map<String, String>` | Metadata: must contain keys `"name"` and `"symbol"`. |
+| `upgradable` | `bool` | If `true`, the Manager can upgrade the vault's WASM without user signatures. |
+
+#### `AssetStrategySet` Structure
+
+```rust
+struct AssetStrategySet {
+    address: Address,          // The token contract address (e.g., USDC or XLM SAC)
+    strategies: Vec<Strategy>, // Strategies that manage this asset
+}
+
+struct Strategy {
+    address: Address, // Strategy contract address
+    name: String,     // Human-readable name (stored on-chain)
+    paused: bool,     // Set to false on creation; strategies start active
+}
+```
+
+#### Example: `stellar-cli` (Testnet, USDC vault)
+
+```bash
+stellar contract invoke \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase 'Test SDF Network ; September 2015' \
+  --id CDSCWE4GLNBYYTES2OCYDFQA2LLY4RBIAX6ZI32VSUXD7GO6HRPO4A32 \
+  --source-account deployer \
+  -- \
+  create_defindex_vault \
+  --roles '{"0":"GCKFBEIY...","1":"GCKFBEIY...","2":"GCKFBEIY...","3":"GCKFBEIY..."}' \
+  --vault_fee 100 \
+  --assets '[{"address":"CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU","strategies":[{"address":"CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY","name":"BlendUSDC Strategy","paused":false}]}]' \
+  --soroswap_router CCJUD55AG6W5HAI5LRVNKAE5WDP5XGZBUDS5WNTIVDU7O264UZZE7BRD \
+  --name_symbol '{"name":"My USDC Vault","symbol":"MUSDC"}' \
+  --upgradable true
+```
+
+> Replace `GCKFBEIY...` with your actual Stellar addresses for each role.
+
+### Function: `create_defindex_vault_deposit`
+
+Creates a vault **and** makes the initial deposit in one transaction.
+
+```rust
+fn create_defindex_vault_deposit(
+    e: Env,
+    caller: Address,
+    roles: Map<u32, Address>,
+    vault_fee: u32,
+    assets: Vec<AssetStrategySet>,
+    soroswap_router: Address,
+    name_symbol: Map<String, String>,
+    upgradable: bool,
+    amounts: Vec<i128>,
+) -> Result<Address, FactoryError>
+```
+
+Additional parameter over `create_defindex_vault`:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `caller` | `Address` | The address that signs the transaction and makes the deposit. |
+| `amounts` | `Vec<i128>` | Initial deposit amounts in stroops, one per asset in the same order as `assets`. Minimum 1001 per asset. |
+
+---
+
+## Method 2: API — `POST /factory/create-vault`
+
+Builds an unsigned XDR to deploy a vault. You must sign the XDR and submit it via `POST /send`.
+
+```http
+POST https://api.defindex.io/factory/create-vault?network=testnet
+Authorization: Bearer <API_KEY>
+Content-Type: application/json
+```
+
+### Request Body
+
+```json
+{
+  "roles": {
+    "manager": "GACKTN5D...",
+    "emergencyManager": "GACKTN5D...",
+    "rebalanceManager": "GACKTN5D...",
+    "feeReceiver": "GACKTN5D..."
+  },
+  "vaultFeeBps": 100,
+  "assets": [
+    {
+      "address": "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU",
+      "strategies": [
+        {
+          "address": "CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY",
+          "name": "BlendUSDC Strategy",
+          "paused": false
+        }
+      ]
+    }
+  ],
+  "name": "My USDC Vault",
+  "symbol": "MUSDC",
+  "upgradable": true,
+  "caller": "GACKTN5D..."
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `roles.manager` | `string` | Yes | Stellar address for the Manager role |
+| `roles.emergencyManager` | `string` | Yes | Stellar address for the Emergency Manager role |
+| `roles.rebalanceManager` | `string` | Yes | Stellar address for the Rebalance Manager role |
+| `roles.feeReceiver` | `string` | Yes | Stellar address for the Fee Receiver role |
+| `vaultFeeBps` | `number` | Yes | Vault fee in basis points (0–10000). `100` = 1% |
+| `assets` | `Asset[]` | Yes | Array of assets the vault will manage |
+| `assets[].address` | `string` | Yes | Token contract address for this asset |
+| `assets[].strategies` | `Strategy[]` | Yes | Strategies that manage this asset |
+| `assets[].strategies[].address` | `string` | Yes | Strategy contract address |
+| `assets[].strategies[].name` | `string` | Yes | Human-readable name stored on-chain |
+| `assets[].strategies[].paused` | `boolean` | Yes | Whether the strategy starts paused. Use `false` |
+| `name` | `string` | Yes | Vault display name (stored on-chain) |
+| `symbol` | `string` | Yes | Vault token symbol for dfTokens (e.g., `MUSDC`) |
+| `upgradable` | `boolean` | Yes | Whether the vault contract can be upgraded by the Manager |
+| `caller` | `string` | Yes | Stellar address of the deployer (signs the transaction) |
+
+### Response
+
+```json
+{
+  "xdr": "AAAAAgAAAAB...",
+  "simulationResponse": { ... },
+  "error": null
+}
+```
+
+Sign the returned `xdr` with the `caller`'s key and submit via `POST /send?network=testnet`.
+
+---
+
+## Method 3: API — `POST /factory/create-vault-deposit`
+
+Creates a vault **and** performs the initial deposit atomically. This is the recommended approach since it handles Steps 3 and 4 in a single transaction.
+
+```http
+POST https://api.defindex.io/factory/create-vault-deposit?network=testnet
+Authorization: Bearer <API_KEY>
+Content-Type: application/json
+```
+
+### Request Body
+
+```json
+{
+  "roles": {
+    "manager": "GACKTN5D...",
+    "emergencyManager": "GACKTN5D...",
+    "rebalanceManager": "GACKTN5D...",
+    "feeReceiver": "GACKTN5D..."
+  },
+  "vaultFeeBps": 100,
+  "assets": [
+    {
+      "address": "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU",
+      "strategies": [
+        {
+          "address": "CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY",
+          "name": "BlendUSDC Strategy",
+          "paused": false
+        }
+      ]
+    }
+  ],
+  "name": "My USDC Vault",
+  "symbol": "MUSDC",
+  "upgradable": true,
+  "caller": "GACKTN5D...",
+  "depositAmounts": [10000000]
+}
+```
+
+### Additional Field
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `depositAmounts` | `number[]` | Yes | Initial deposit amounts in **stroops**, one per asset in the same order as `assets`. Must be ≥ 1001 per asset. |
+
+All other fields are identical to `create-vault` above.
+
+> **Decimal reference:** 1 USDC = `10_000_000` stroops (7 decimals). 1 XLM = `10_000_000` stroops. The minimum `1001` stroops equals **0.0001001 units**.
+
+### Response
+
+Same shape as `create-vault`:
+
+```json
+{
+  "xdr": "AAAAAgAAAAB...",
+  "simulationResponse": { ... },
+  "error": null
+}
+```
+
+---
+
+## Method 4: API — `POST /factory/create-vault-auto-invest`
+
+Creates a vault, makes the initial deposit, **and** immediately rebalances (invests) into strategies — all in one batched transaction. At the end it also transfers the Manager role to the final address. This is the most convenient option for fully automated deployments.
+
+```http
+POST https://api.defindex.io/factory/create-vault-auto-invest?network=testnet
+Authorization: Bearer <API_KEY>
+Content-Type: application/json
+```
+
+### Request Body
+
+```json
+{
+  "caller": "GBZXUKUY...",
+  "roles": {
+    "manager": "GBAJGSZQ...",
+    "emergencyManager": "GBAJGSZQ...",
+    "rebalanceManager": "GBAJGSZQ...",
+    "feeReceiver": "GBAJGSZQ..."
+  },
+  "name": "Auto-Invest USDC Vault",
+  "symbol": "AIUSDC",
+  "vaultFee": 100,
+  "upgradable": true,
+  "assets": [
+    {
+      "address": "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU",
+      "symbol": "USDC",
+      "amount": 10000000,
+      "strategies": [
+        {
+          "address": "CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY",
+          "name": "BlendUSDC Strategy",
+          "amount": 10000000
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caller` | `string` | Yes | Deployer's Stellar address. Signs the transaction. The manager role is transferred from this address to `roles.manager` at the end. |
+| `roles.manager` | `string` | Yes | Final Manager address after deployment |
+| `roles.emergencyManager` | `string` | Yes | Emergency Manager address |
+| `roles.rebalanceManager` | `string` | Yes | Rebalance Manager address |
+| `roles.feeReceiver` | `string` | Yes | Fee Receiver address |
+| `name` | `string` | Yes | Vault display name |
+| `symbol` | `string` | Yes | dfToken symbol (e.g., `AIUSDC`) |
+| `vaultFee` | `number` | Yes | Vault fee in basis points. Note: this field is named `vaultFee` (not `vaultFeeBps`) for this endpoint. |
+| `upgradable` | `boolean` | Yes | Whether the vault contract can be upgraded |
+| `assets` | `Asset[]` | Yes | Assets to manage |
+| `assets[].address` | `string` | Yes | Token contract address |
+| `assets[].symbol` | `string` | Yes | Human-readable token symbol |
+| `assets[].amount` | `number` | Yes | Total deposit amount for this asset in stroops. Must be ≥ 1001 and equal to the sum of all strategy amounts. |
+| `assets[].strategies` | `Strategy[]` | Yes | Strategies for this asset |
+| `assets[].strategies[].address` | `string` | Yes | Strategy contract address |
+| `assets[].strategies[].name` | `string` | Yes | Strategy name |
+| `assets[].strategies[].amount` | `number` | Yes | Amount (in stroops) to invest into this strategy. The sum of all strategy amounts must equal `assets[].amount`. |
+
+> **Strategy amounts must sum to the asset amount.** If `assets[0].amount = 10000000`, then all `strategies[].amount` values for that asset must add up to `10000000`.
+
+### Response
+
+```json
+{
+  "xdr": "AAAAAgAAAAA...",
+  "predictedVaultAddress": "CCQ2BCKKDX7HSF5TULLRFRKS4RYIC5ZZGYYTBR3XFDLZ6MMZFRJNXIEA",
+  "warning": "The vault address is predicted from simulation. Actual address may differ if network state changes."
+}
+```
+
+The `predictedVaultAddress` is derived from simulation and is accurate in most cases, but treat it as advisory until the transaction confirms on-chain.
+
+---
+
+## Complete Testnet Example (TypeScript)
+
+This example deploys a BlendUSDC vault on testnet using the `create-vault-deposit` endpoint.
+
+> **Before running**: Make sure you have BlendUSDC in your wallet. Go to [testnet.blend.capital](https://testnet.blend.capital), connect your Freighter wallet (on Testnet), and use the faucet to receive BlendUSDC.
+
+```typescript
+const API_KEY = process.env.DEFINDEX_API_KEY!;
+const DEPLOYER_ADDRESS = "GACKTN5D..."; // Your Stellar testnet address
+
+const body = {
+  roles: {
+    manager: DEPLOYER_ADDRESS,
+    emergencyManager: DEPLOYER_ADDRESS,
+    rebalanceManager: DEPLOYER_ADDRESS,
+    feeReceiver: DEPLOYER_ADDRESS,
+  },
+  vaultFeeBps: 100, // 1%
+  assets: [
+    {
+      // BlendUSDC on testnet
+      address: "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU",
+      strategies: [
+        {
+          address: "CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY",
+          name: "Blend USDC Strategy",
+          paused: false,
+        },
+      ],
+    },
+  ],
+  name: "My USDC Vault",
+  symbol: "MUSDC",
+  upgradable: true,
+  caller: DEPLOYER_ADDRESS,
+  depositAmounts: [1001], // Minimum first deposit (1001 stroops)
+};
+
+// Step 1: Build the transaction
+const res = await fetch(
+  "https://api.defindex.io/factory/create-vault-deposit?network=testnet",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify(body),
+  }
+);
+const { xdr } = await res.json();
+
+// Step 2: Sign with your wallet (Freighter / Privy / Crossmint)
+const signedXdr = await signTransaction(xdr, { network: "TESTNET" });
+
+// Step 3: Submit
+const sendRes = await fetch(
+  "https://api.defindex.io/send?network=testnet",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify({ xdr: signedXdr }),
+  }
+);
+const result = await sendRes.json();
+console.log("Vault deployed:", result.txHash);
+```
+
+---
+
+## Complete Mainnet Example (TypeScript)
+
+```typescript
+const body = {
+  roles: {
+    manager: "GMANAGER...",
+    emergencyManager: "GEMERGENCY...",
+    rebalanceManager: "GREBALANCE...",
+    feeReceiver: "GFEERECEIVER...",
+  },
+  vaultFeeBps: 50, // 0.5%
+  assets: [
+    {
+      // Real USDC on mainnet (Circle / Stellar SAC)
+      address: "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+      strategies: [
+        {
+          address: "CDB2WMKQQNVZMEBY7Q7GZ5C7E7IAFSNMZ7GGVD6WKTCEWK7XOIAVZSAP",
+          name: "Blend USDC Fixed Strategy",
+          paused: false,
+        },
+      ],
+    },
+  ],
+  name: "My USDC Vault",
+  symbol: "MUSDC",
+  upgradable: true,
+  caller: "GDEPLOYER...",
+  depositAmounts: [1001], // 0.0001001 USDC — the required minimum
+};
+
+const res = await fetch(
+  "https://api.defindex.io/factory/create-vault-deposit?network=mainnet",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify(body),
+  }
+);
+const { xdr } = await res.json();
+// ... sign and send as above
+```
+
+---
+
+## After Deployment: First Rebalance
+
+After the vault is deployed and the first deposit is made, call the `rebalance` function to invest funds into your chosen strategies. Without this step, all deposited funds remain **idle** (uninvested) in the vault.
+
+See the [Rebalance section in the main Create a Vault guide](README.md#step-5-first-rebalance) for how to do this via the API or `stellar-cli`.
+
+> If you used `create-vault-auto-invest`, the initial rebalance is already done for you as part of the deployment transaction.
+
+---
+
+## Testnet vs Mainnet Differences at a Glance
+
+| Aspect | Testnet | Mainnet |
+|---|---|---|
+| USDC | BlendUSDC (`CAQCFV...`) — get from testnet.blend.capital | Circle USDC (`CCW67T...`) |
+| CETES | Testnet CETES (`CC72F5...`) — get from testnet.blend.capital | Real CETES token |
+| XLM | Testnet XLM — get from Friendbot | Real XLM |
+| Factory | `CDSCWE4...` | `CDKFHFJ...` |
+| API `network` param | `testnet` | `mainnet` |
+| Network passphrase | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| RPC URL | `https://soroban-testnet.stellar.org` | Provider-dependent |
+
+---
+
+## Troubleshooting
+
+**`StrategyDoesNotSupportAsset` (error 102)**\
+The strategy address you provided does not support the asset token you specified. Double-check that the strategy address matches the asset and the strategy/asset/network relation is correct. For example, the USDC strategy cannot be used with the XLM token address or, the USDC strategy on testnet cannot be used with the USDC token address from mainnet.
+
+**Transaction fails with simulation error on testnet**\
+You may not have a BlendUSDC trustline. Visit [testnet.blend.capital](https://testnet.blend.capital), connect your wallet, and add the BlendUSDC asset before trying again.
+
+**`RolesIncomplete` (error 104)**\
+All four roles (0–3) must be provided. If you leave any out, the factory will reject the transaction.
+
+**`FeeTooHigh` (factory error 406)**\
+The `vaultFeeBps` value exceeds the maximum allowed. Keep it at or below 10,000 (100%).
+
+**`AmountNotAllowed` (error 110)**\
+The initial deposit amount is zero or negative. Provide at least 1001 stroops per asset.
+
+For additional errors, see the [Troubleshooting Guide](../troubleshooting.md).

--- a/apps/docs/api-integration-guide/creating-a-defindex-vault/using-the-factory-advanced.md
+++ b/apps/docs/api-integration-guide/creating-a-defindex-vault/using-the-factory-advanced.md
@@ -30,7 +30,7 @@ Testnet addresses may be not valid after the June 17 or December 16, 2026, testn
 | Contract | Address |
 |---|---|
 | Factory | `CDKFHFJIET3A73A2YN4KV7NSV32S6YGQMUFH3DNJXLBWL4SKEGVRNFKI` |
-| Soroswap Router | See [api.soroswap.finance/api/mainnet/router](https://api.soroswap.finance/api/mainnet/router) |
+| Soroswap Router | `CAG5LRYQ5JVEUI5TEID72EYOVX44TTUJT5BQR2J6J77FH65PCCFAJDDH` |
 | XLM (native SAC) | `CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` |
 | USDC (Circle) | `CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75` |
 | USDC Fixed Pool Strategy | `CDB2WMKQQNVZMEBY7Q7GZ5C7E7IAFSNMZ7GGVD6WKTCEWK7XOIAVZSAP` |


### PR DESCRIPTION
## Summary

Closes #828

- Added a **"Vault Creation Requirements"** section to the Create a Vault overview page, covering the testnet/mainnet network differences, token types (BlendUSDC vs Circle USDC), how to obtain testnet tokens (Friendbot + testnet.blend.capital), and the minimum first-deposit requirement (1001 stroops) with its inflation-attack rationale.
- Fully rewrote **Using the Factory (Advanced)** with complete argument documentation for all four deployment methods: direct factory contract call (`create_defindex_vault` and `create_defindex_vault_deposit` with Rust signatures and `stellar-cli` examples), and all three API endpoints (`create-vault`, `create-vault-deposit`, `create-vault-auto-invest`) with field-by-field reference tables, role ID table, token address tables for both networks, complete TypeScript examples, a testnet vs mainnet diff table, and a troubleshooting section.

## Test plan

- [x] Verify rendered output on GitBook (tables, code blocks, cross-links)
- [ ] Confirm all contract addresses match `public/testnet.contracts.json` and `public/mainnet.contracts.json`
- [ ] Follow the testnet TypeScript example end-to-end to validate accuracy